### PR TITLE
usdt_strtab_add returns 0 on error

### DIFF
--- a/usdt.c
+++ b/usdt.c
@@ -107,7 +107,7 @@ usdt_provider_enable(usdt_provider_t *provider)
                 return (-1);
         }
 
-        if ((usdt_strtab_add(&strtab, provider->name)) < 0) {
+        if ((usdt_strtab_add(&strtab, provider->name)) == 0) {
                 usdt_error(provider, USDT_ERROR_MALLOC);
                 return (-1);
         }

--- a/usdt_dof.c
+++ b/usdt_dof.c
@@ -112,11 +112,11 @@ usdt_strtab_add(usdt_strtab_t *strtab, const char *string)
         strtab->strindex += (length + 1);
 
         if ((strtab->data = realloc(strtab->data, strtab->strindex)) == NULL)
-                return (-1);
+                return (0);
 
         memcpy((char *) (strtab->data + index), (char *)string, length + 1);
         strtab->size = index + length + 1;
 
-        return index;
+        return (index);
 }
 


### PR DESCRIPTION
I figured I'd jump the gun and do a pull request. This is an issue on master as well as the unload_dof branch.

I'm really not sure how to test this, apart from the fact that libusdt does not build without the change. I can spend more time understanding the test framework if you'd like, to make a failing/passing test under gcc.
