### PR TITLE
chrisa/libusdt#12 usdt_probe_args on i386 should leave %ebx alone

### DIFF
--- a/usdt_tracepoints_i386.s
+++ b/usdt_tracepoints_i386.s
@@ -54,7 +54,7 @@ _usdt_probe_args:
         movl    %esp,%ebp
         subl    $8,%esp
         subl    $8,%esp
-        movl    8(%ebp),%ebx 
+        movl    8(%ebp),%edx
         movl    0xc(%ebp),%ecx
         test    %ecx,%ecx
         je      fire
@@ -65,5 +65,5 @@ args:   movl    %ecx,%eax
         pushl   (%eax)
         dec     %ecx
         jne     args
-fire:   jmp     *%ebx
+fire:   jmp     *%edx
 


### PR DESCRIPTION
I ran`sudo make test` with this change on both Mac OS X and SmartOS, and also ran the `node-dtrace-provider` test suite on both platforms with this change.