### PR TITLE
FreeBSD 11 Support

### DIFF
--- a/usdt_dof_file.c
+++ b/usdt_dof_file.c
@@ -63,7 +63,10 @@ load_dof(int fd, dof_helper_t *dh)
         int ret;
 
         ret = ioctl(fd, DTRACEHIOC_ADDDOF, dh);
-
+#if __FreeBSD__ <= 10
+	if (ret != -1) 
+	    ret = dh ->gen;
+#endif
         return ret;
 }
 
@@ -178,7 +181,7 @@ usdt_dof_file_load(usdt_dof_file_t *file, const char *module)
 
         dh.dofhp_dof  = (uintptr_t)dof;
         dh.dofhp_addr = (uintptr_t)dof;
-#ifdef __FreeBSD__
+#if __FreeBSD__ >= 11
         dh.dofhp_pid = getpid();
 #endif
         (void) strncpy(dh.dofhp_mod, module, sizeof (dh.dofhp_mod));

--- a/usdt_dof_file.c
+++ b/usdt_dof_file.c
@@ -64,10 +64,6 @@ load_dof(int fd, dof_helper_t *dh)
 
         ret = ioctl(fd, DTRACEHIOC_ADDDOF, dh);
 
-#ifdef __FreeBSD__
-        if (ret != -1)
-                ret = dh->gen;
-#endif
         return ret;
 }
 
@@ -182,6 +178,9 @@ usdt_dof_file_load(usdt_dof_file_t *file, const char *module)
 
         dh.dofhp_dof  = (uintptr_t)dof;
         dh.dofhp_addr = (uintptr_t)dof;
+#ifdef __FreeBSD__
+        dh.dofhp_pid = getpid();
+#endif
         (void) strncpy(dh.dofhp_mod, module, sizeof (dh.dofhp_mod));
 
         if ((fd = open(helper, O_RDWR)) < 0)


### PR DESCRIPTION
Resubmitting this following update from @melloc 
Tests still pass on FreeBSD 11

```
sudo prove test.pl
test.pl .. ok    
All tests successful.
Files=1, Tests=66, 15 wallclock secs ( 0.04 usr  0.02 sys +  1.38 cusr  1.03 csys =  2.47 CPU)                                                                
Result: PASS
```
