### PR TITLE
chrisa/libusdt#16 building for x86 (32bits) target on amd64 host architecture fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ endif
 endif 
 ifeq ($(ARCH), x86_64)
 CFLAGS += -m64
+else
+CFLAGS += -m32
 endif
 endif
 


### PR DESCRIPTION
This change fixes #16 and has been tested in a SmartOS VM as following:

```
[root@ff16a225-3889-4644-a2a7-b5b963bcdded ~/dev/libusdt]# uname -a
SunOS ff16a225-3889-4644-a2a7-b5b963bcdded 5.11 joyent_20160721T174127Z i86pc i386 i86pc Solaris
[root@ff16a225-3889-4644-a2a7-b5b963bcdded ~/dev/libusdt]# git branch
  fix-32bits-build
* master
[root@ff16a225-3889-4644-a2a7-b5b963bcdded ~/dev/libusdt]# make clean
rm -f *.gch
rm -f *.o
rm -f libusdt.a
rm -f test_usdt
rm -f test_usdt32
rm -f test_usdt64
rm -f test_mem_usage
[root@ff16a225-3889-4644-a2a7-b5b963bcdded ~/dev/libusdt]# ARCH=i386 make test
gcc -O2 -Wall -fPIC   -c -o usdt.o usdt.c
gcc -O2 -Wall -fPIC   -c -o usdt_dof_file.o usdt_dof_file.c
gcc -O2 -Wall -fPIC -o usdt_tracepoints.o -c usdt_tracepoints_i386.s
usdt_tracepoints_i386.s: Assembler messages:
usdt_tracepoints_i386.s:25: Error: invalid instruction suffix for `push'
usdt_tracepoints_i386.s:53: Error: invalid instruction suffix for `push'
usdt_tracepoints_i386.s:65: Error: invalid instruction suffix for `push'
usdt_tracepoints_i386.s:68: Error: operand type mismatch for `jmp'
Makefile:107: recipe for target 'usdt_tracepoints.o' failed
make: *** [usdt_tracepoints.o] Error 1
[root@ff16a225-3889-4644-a2a7-b5b963bcdded ~/dev/libusdt]# git checkout fix-32bits-build
Switched to branch 'fix-32bits-build'
Your branch is up-to-date with 'origin/fix-32bits-build'.
[root@ff16a225-3889-4644-a2a7-b5b963bcdded ~/dev/libusdt]# make clean
rm -f *.gch
rm -f *.o
rm -f libusdt.a
rm -f test_usdt
rm -f test_usdt32
rm -f test_usdt64
rm -f test_mem_usage
[root@ff16a225-3889-4644-a2a7-b5b963bcdded ~/dev/libusdt]# ARCH=i386 make test
gcc -O2 -Wall -fPIC -m32   -c -o usdt.o usdt.c
gcc -O2 -Wall -fPIC -m32   -c -o usdt_dof_file.o usdt_dof_file.c
gcc -O2 -Wall -fPIC -m32 -o usdt_tracepoints.o -c usdt_tracepoints_i386.s
gcc -O2 -Wall -fPIC -m32   -c -o usdt_probe.o usdt_probe.c
gcc -O2 -Wall -fPIC -m32   -c -o usdt_dof.o usdt_dof.c
gcc -O2 -Wall -fPIC -m32   -c -o usdt_dof_sections.o usdt_dof_sections.c
rm -f libusdt.a
ar cru libusdt.a usdt.o usdt_dof_file.o usdt_tracepoints.o usdt_probe.o usdt_dof.o usdt_dof_sections.o 
/bin/true libusdt.a
gcc -O2 -Wall -fPIC -m32   -c -o test_usdt.o test_usdt.c
gcc -O2 -Wall -fPIC -m32 -o test_usdt test_usdt.o libusdt.a 
sudo prove test.pl
test.pl .. ok      
All tests successful.
Files=1, Tests=1254, 185 wallclock secs ( 0.25 usr  0.03 sys + 77.40 cusr 39.73 csys = 117.42 CPU)
Result: PASS
[root@ff16a225-3889-4644-a2a7-b5b963bcdded ~/dev/libusdt]#
```