### PR TITLE
Add Linux support

### DIFF
--- a/usdt-common.c
+++ b/usdt-common.c
@@ -1,0 +1,132 @@
+#include <stdarg.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "usdt.h"
+
+char *usdt_errors[] = {
+  "failed to allocate memory",
+  "failed to allocate page-aligned memory",
+  "no probes defined",
+  "failed to load DOF: %s",
+  "provider is already enabled",
+  "failed to unload DOF: %s",
+  "probe named %s:%s:%s:%s already exists",
+  "failed to remove probe %s:%s:%s:%s"
+};
+
+usdt_provider_t *
+usdt_create_provider(const char *name, const char *module)
+{
+        usdt_provider_t *provider;
+
+        if ((provider = malloc(sizeof *provider)) == NULL)
+                return NULL;
+
+        provider->name = strdup(name);
+        provider->module = strdup(module);
+        provider->probedefs = NULL;
+        provider->enabled = 0;
+
+        return provider;
+}
+
+usdt_probedef_t *
+usdt_create_probe(const char *func, const char *name, size_t argc, const char **types)
+{
+        int i;
+        usdt_probedef_t *p;
+
+        if (argc > USDT_ARG_MAX)
+                argc = USDT_ARG_MAX;
+
+        if ((p = malloc(sizeof *p)) == NULL)
+                return (NULL);
+
+        p->refcnt = 2;
+        p->function = strdup(func);
+        p->name = strdup(name);
+        p->argc = argc;
+        p->probe = NULL;
+
+        for (i = 0; i < argc; i++)
+                p->types[i] = strdup(types[i]);
+
+        return (p);
+}
+
+int
+usdt_provider_add_probe(usdt_provider_t *provider, usdt_probedef_t *probedef)
+{
+        usdt_probedef_t *pd;
+
+        if (provider->probedefs != NULL) {
+                for (pd = provider->probedefs; (pd != NULL); pd = pd->next) {
+                if ((strcmp(pd->name, probedef->name) == 0) &&
+                    (strcmp(pd->function, probedef->function) == 0)) {
+                                usdt_error(provider, USDT_ERROR_DUP_PROBE,
+                                           provider->name, provider->module,
+                                           probedef->function, probedef->name);
+                                return (-1);
+                        }
+                }
+        }
+
+        probedef->next = NULL;
+        if (provider->probedefs == NULL)
+                provider->probedefs = probedef;
+        else {
+                for (pd = provider->probedefs; (pd->next != NULL); pd = pd->next) ;
+                pd->next = probedef;
+        }
+
+        return (0);
+}
+
+int
+usdt_provider_remove_probe(usdt_provider_t *provider, usdt_probedef_t *probedef)
+{
+        usdt_probedef_t *pd, *prev_pd = NULL;
+
+        if (provider->probedefs == NULL) {
+                usdt_error(provider, USDT_ERROR_NOPROBES);
+                return (-1);
+        }
+
+        for (pd = provider->probedefs; (pd != NULL);
+             prev_pd = pd, pd = pd->next) {
+
+                if ((strcmp(pd->name, probedef->name) == 0) &&
+                    (strcmp(pd->function, probedef->function) == 0)) {
+
+                        if (prev_pd == NULL)
+                                provider->probedefs = pd->next;
+                        else
+                                prev_pd->next = pd->next;
+
+                        return (0);
+                }
+        }
+
+        usdt_error(provider, USDT_ERROR_REMOVE_PROBE,
+                   provider->name, provider->module,
+                   probedef->function, probedef->name);
+        return (-1);
+}
+
+static void
+usdt_verror(usdt_provider_t *provider, usdt_error_t error, va_list argp)
+{
+        (void)vasprintf(&provider->error, usdt_errors[error], argp);
+}
+
+void usdt_error(usdt_provider_t *provider, usdt_error_t error, ...) {
+  va_list argp;
+
+  va_start(argp, error);
+  usdt_verror(provider, error, argp);
+  va_end(argp);
+}
+char *usdt_errstr(usdt_provider_t *provider) {
+  return (provider->error);
+}

--- a/usdt-systemtap.c
+++ b/usdt-systemtap.c
@@ -1,0 +1,176 @@
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <string.h>
+#include <libstapsdt.h>
+
+#include "usdt.h"
+
+ArgType_t stringToArgType(char *type) {
+  // TODO (mmarchini) better mapping of arguments, but for now this works
+  return uint64;
+}
+
+void usdt_fire_probe(usdt_probe_t *probe, size_t argc, void **argv) {
+  if (probe == NULL)
+    return;
+
+  switch(argc) {
+    case 0:
+      probeFire((SDTProbe_t *)probe->probe_addr);
+      break;
+    case 1:
+      probeFire((SDTProbe_t *)probe->probe_addr, argv[0]);
+      break;
+    case 2:
+      probeFire((SDTProbe_t *)probe->probe_addr, argv[0], argv[1]);
+      break;
+    case 3:
+      probeFire((SDTProbe_t *)probe->probe_addr, argv[0], argv[1], argv[2]);
+      break;
+    case 4:
+      probeFire((SDTProbe_t *)probe->probe_addr, argv[0], argv[1], argv[2], argv[3]);
+      break;
+    case 5:
+      probeFire((SDTProbe_t *)probe->probe_addr, argv[0], argv[1], argv[2], argv[3], argv[4]);
+      break;
+    case 6:
+      probeFire((SDTProbe_t *)probe->probe_addr, argv[0], argv[1], argv[2], argv[3], argv[4], argv[5]);
+      break;
+    default:
+      probeFire((SDTProbe_t *)probe->probe_addr);
+  }
+}
+
+int usdt_provider_enable(usdt_provider_t *provider) {
+  SDTProvider_t *stapProvider = providerInit(provider->name);
+  SDTProbe_t *stapProbe;
+  for(usdt_probedef_t *node=provider->probedefs; node!=NULL; node=node->next) {
+    node->probe = calloc(sizeof(usdt_probe_t), 1);
+    node->probe->isenabled_addr = NULL;
+    switch(node->argc) {
+      case 0:
+        stapProbe = providerAddProbe(stapProvider, node->name, node->argc);
+        break;
+      case 1:
+        stapProbe = providerAddProbe(stapProvider, node->name, node->argc,
+          stringToArgType(((node->types))[0]));
+        break;
+      case 2:
+        stapProbe = providerAddProbe(stapProvider, node->name, node->argc,
+          stringToArgType(((node->types))[0]),
+          stringToArgType(((node->types))[1]));
+        break;
+      case 3:
+        stapProbe = providerAddProbe(stapProvider, node->name, node->argc,
+          stringToArgType(((node->types))[0]),
+          stringToArgType(((node->types))[1]),
+          stringToArgType(((node->types))[2]));
+        break;
+      case 4:
+        stapProbe = providerAddProbe(stapProvider, node->name, node->argc,
+          stringToArgType(((node->types))[0]),
+          stringToArgType(((node->types))[1]),
+          stringToArgType(((node->types))[2]),
+          stringToArgType(((node->types))[3]));
+        break;
+      case 5:
+        stapProbe = providerAddProbe(stapProvider, node->name, node->argc,
+          stringToArgType(((node->types))[0]),
+          stringToArgType(((node->types))[1]),
+          stringToArgType(((node->types))[2]),
+          stringToArgType(((node->types))[3]),
+          stringToArgType(((node->types))[4]));
+        break;
+      case 6:
+        stapProbe = providerAddProbe(stapProvider, node->name, node->argc,
+          stringToArgType(((node->types))[0]),
+          stringToArgType(((node->types))[1]),
+          stringToArgType(((node->types))[2]),
+          stringToArgType(((node->types))[3]),
+          stringToArgType(((node->types))[4]),
+          stringToArgType(((node->types))[5]));
+        break;
+      default:
+        stapProbe = providerAddProbe(stapProvider, node->name, 0);
+    }
+    node->probe->probe_addr = (void *)stapProbe;
+  }
+  provider->file = (void *)stapProvider;
+  if(providerLoad(stapProvider) == 0) {
+    provider->enabled = 1;
+    return 0;
+  }
+  else {
+    return -1;
+  }
+}
+
+int usdt_is_enabled(usdt_probe_t *probe) {
+  if(probe == NULL) {
+    return 0;
+  }
+  if(probe->probe_addr == NULL) {
+    return 0;
+  }
+  return probeIsEnabled((SDTProbe_t *) probe->probe_addr);
+}
+
+void free_probedef(usdt_probedef_t *pd) {
+  int i;
+
+  free((char *)pd->function);
+  free((char *)pd->name);
+
+  pd->probe = NULL;
+
+  for (i = 0; i < pd->argc; i++) {
+    free(pd->types[i]);
+  }
+
+  free(pd);
+}
+
+void usdt_probe_release(usdt_probedef_t *probedef) {
+  free_probedef(probedef);
+}
+
+int usdt_provider_disable(usdt_provider_t *provider) {
+  usdt_probedef_t *pd;
+
+  if (provider->enabled == 0)
+          return (0);
+
+  if ((providerUnload((SDTProvider_t *)provider->file)) < 0) {
+          usdt_error(provider, USDT_ERROR_UNLOADDOF, strerror(errno));
+          return (-1);
+  }
+
+  providerDestroy((SDTProvider_t *)provider->file);
+  provider->file = NULL;
+
+  /* providerDestroy already frees all probes, so we only need to set them to NULL here */
+  for (pd = provider->probedefs; (pd != NULL); pd = pd->next) {
+    if (pd->probe) {
+      pd->probe = NULL;
+    }
+  }
+
+  provider->enabled = 0;
+
+  return (0);
+}
+
+void usdt_provider_free(usdt_provider_t *provider) {
+  usdt_probedef_t *pd, *next;
+
+  for (pd = provider->probedefs; pd != NULL; pd = next) {
+    next = pd->next;
+    free_probedef(pd);
+  }
+
+  free((char *)provider->name);
+  free((char *)provider->module);
+  free(provider);
+}

--- a/usdt.c
+++ b/usdt.c
@@ -8,17 +8,6 @@
 #include <string.h>
 #include <stdio.h>
 
-char *usdt_errors[] = {
-  "failed to allocate memory",
-  "failed to allocate page-aligned memory",
-  "no probes defined",
-  "failed to load DOF: %s",
-  "provider is already enabled",
-  "failed to unload DOF: %s",
-  "probe named %s:%s:%s:%s already exists",
-  "failed to remove probe %s:%s:%s:%s"
-};
-
 static void
 free_probedef(usdt_probedef_t *pd)
 {
@@ -44,109 +33,10 @@ free_probedef(usdt_probedef_t *pd)
         }
 }
 
-usdt_provider_t *
-usdt_create_provider(const char *name, const char *module)
-{
-        usdt_provider_t *provider;
-
-        if ((provider = malloc(sizeof *provider)) == NULL) 
-                return NULL;
-
-        provider->name = strdup(name);
-        provider->module = strdup(module);
-        provider->probedefs = NULL;
-        provider->enabled = 0;
-
-        return provider;
-}
-
-usdt_probedef_t *
-usdt_create_probe(const char *func, const char *name, size_t argc, const char **types)
-{
-        int i;
-        usdt_probedef_t *p;
-
-        if (argc > USDT_ARG_MAX)
-                argc = USDT_ARG_MAX;
-
-        if ((p = malloc(sizeof *p)) == NULL)
-                return (NULL);
-
-        p->refcnt = 2;
-        p->function = strdup(func);
-        p->name = strdup(name);
-        p->argc = argc;
-        p->probe = NULL;
-
-        for (i = 0; i < argc; i++)
-                p->types[i] = strdup(types[i]);
-
-        return (p);
-}
-
 void
 usdt_probe_release(usdt_probedef_t *probedef)
 {
         free_probedef(probedef);
-}
-
-int
-usdt_provider_add_probe(usdt_provider_t *provider, usdt_probedef_t *probedef)
-{
-        usdt_probedef_t *pd;
-
-        if (provider->probedefs != NULL) {
-                for (pd = provider->probedefs; (pd != NULL); pd = pd->next) {
-                if ((strcmp(pd->name, probedef->name) == 0) &&
-                    (strcmp(pd->function, probedef->function) == 0)) {
-                                usdt_error(provider, USDT_ERROR_DUP_PROBE,
-                                           provider->name, provider->module,
-                                           probedef->function, probedef->name);
-                                return (-1);
-                        }
-                }
-        }
-
-        probedef->next = NULL;
-        if (provider->probedefs == NULL)
-                provider->probedefs = probedef;
-        else {
-                for (pd = provider->probedefs; (pd->next != NULL); pd = pd->next) ;
-                pd->next = probedef;
-        }
-
-        return (0);
-}
-
-int
-usdt_provider_remove_probe(usdt_provider_t *provider, usdt_probedef_t *probedef)
-{
-        usdt_probedef_t *pd, *prev_pd = NULL;
-
-        if (provider->probedefs == NULL) {
-                usdt_error(provider, USDT_ERROR_NOPROBES);
-                return (-1);
-        }
-
-        for (pd = provider->probedefs; (pd != NULL);
-             prev_pd = pd, pd = pd->next) {
-
-                if ((strcmp(pd->name, probedef->name) == 0) &&
-                    (strcmp(pd->function, probedef->function) == 0)) {
-
-                        if (prev_pd == NULL)
-                                provider->probedefs = pd->next;
-                        else
-                                prev_pd->next = pd->next;
-
-                        return (0);
-                }
-        }
-
-        usdt_error(provider, USDT_ERROR_REMOVE_PROBE,
-                   provider->name, provider->module,
-                   probedef->function, probedef->name);
-        return (-1);
 }
 
 int
@@ -296,26 +186,4 @@ usdt_fire_probe(usdt_probe_t *probe, size_t argc, void **nargv)
 {
         if (probe != NULL)
                 usdt_probe_args(probe->probe_addr, argc, nargv);
-}
-
-static void
-usdt_verror(usdt_provider_t *provider, usdt_error_t error, va_list argp)
-{
-        vasprintf(&provider->error, usdt_errors[error], argp);
-}
-
-void
-usdt_error(usdt_provider_t *provider, usdt_error_t error, ...)
-{
-        va_list argp;
-
-        va_start(argp, error);
-        usdt_verror(provider, error, argp);
-        va_end(argp);
-}
-
-char *
-usdt_errstr(usdt_provider_t *provider)
-{
-        return (provider->error);
 }


### PR DESCRIPTION
Add Linux support by using libstapsdt - a library for creating runtime Systemtap's SDT probes on Linux. Today libusdt doesn't work on Linux because it relies only on DTrace's USDT probes. Systemtap SDT is very similar externally to DTrace's USDT, although they implementation very differently. Those changes shouldn't break libusdt on other systems because they are isolated in another file. I also moved all common functions to a `usdt-common.c` file, to avoid code duplication.

This is one suggestion on how to make `libusdt` work on Linux. If you have any other suggestions, I'll be pleased to work on them.